### PR TITLE
Ajout d'une configuration pour la suspension du formulaire public

### DIFF
--- a/apps/api/src/config.js
+++ b/apps/api/src/config.js
@@ -65,6 +65,12 @@ const config = convict({
         default: 3001,
         env: 'API_PORT'
     },
+    suspendedOrders: {
+        doc: 'Suspended Public Order Form',
+        format: 'Boolean',
+        default: true,
+        env: 'SUSPENDED_ORDERS'
+    },
     mailjet: {
         publicKey: {
             doc: 'Mailjet API public key',

--- a/apps/api/src/front.js
+++ b/apps/api/src/front.js
@@ -8,6 +8,7 @@ const signale = require('signale');
 const dbMiddleware = require('./dbMiddleware');
 const { insertOne, getOne } = require('./request/repository');
 const { sendRequestConfirmation } = require('./toolbox/mailjet');
+const config = require('./config');
 
 const { getGlobalStats } = require('./stat/repository');
 
@@ -51,7 +52,10 @@ const renderCachedHomepage = async (ctx) => {
     } catch (error) {
         signale.error(error);
     }
-    return ctx.render('suspended.ejs');
+
+    return config.suspendedOrders
+        ? ctx.render('suspended.ejs')
+        : ctx.render('index.ejs');
 };
 
 router.get('/', renderCachedHomepage);

--- a/config/development.env
+++ b/config/development.env
@@ -7,3 +7,5 @@ POSTGRES_HOST=postgres
 
 REACT_APP_API_URL=http://localhost:8001
 REACT_APP_HTTP_CREDENTIALS=include
+
+SUSPENDED_ORDERS=false


### PR DESCRIPTION
Tout compte fait, c'est un peu galère d'avoir en dur le switch de suspension du formulaire publique de prise de commande. Ce n'est vraiment pas pratique pour faire des tests en local.

J'ai donc ajouter une configuration pour mettre le formulaire on/off, qui est `false` par default pour ne pas avoir à gérer de variable d'environement spécifique en production.